### PR TITLE
Update SECURITY.md to reflect bug bounty program

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,8 @@
 # Reporting and Fixing Security Issues
 
-Please report all security issues to the LaunchDarkly security team by submitting a bug bounty report to our [HackerOne program](https://hackerone.com/launchdarkly?type=team). LaunchDarkly will triage and address all valid security issues following the response targets defined in our program policy. Valid security issues may be eligible for a bounty.
+**Do not open Issues or Pull Requests for security issues.**  
+This will make potential issues publicly visible before LaunchDarkly's Security Team can address them, which could lead to a compromise of the platform and negatively impact our customers. 
 
-Please do not open issues or pull requests for security issues. This makes the problem immediately visible to everyone, including potentially malicious actors.
+Security issues must be reported through our [Bug Bounty program](https://bugcrowd.com/engagements/launchdarkly-mbb-og), following the program policy, for triage and remediation by the LaunchDarkly Security Team. Valid security issues may be eligible for a bounty.
+
+Please do not attempt to directly contact members of LaunchDarkly staff.


### PR DESCRIPTION
## Summary

Updates `SECURITY.md` to direct security reporters to LaunchDarkly's Bug Bounty program.

## Changes

- Security issues should be reported through the [Bug Bounty program](https://bugcrowd.com/engagements/launchdarkly-mbb-og) rather than via GitHub Issues or PRs
- Clarifies that valid security issues may be eligible for a bounty

This is a cross-repository update to standardize security reporting instructions across LaunchDarkly repositories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to security reporting instructions; no application or infrastructure code is modified.
> 
> **Overview**
> **`SECURITY.md`** is updated so security reporting matches LaunchDarkly’s current process across repos.
> 
> The doc now **boldly warns** not to file GitHub Issues or PRs for vulnerabilities, with clearer rationale about public exposure. Reporting is directed to the **Bugcrowd** [Bug Bounty program](https://bugcrowd.com/engagements/launchdarkly-mbb-og) instead of the previous **HackerOne** link, and a line is added asking reporters **not to contact LaunchDarkly staff directly**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e4f8f8672685260c75a4f9d1a9f4a51b5f60b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->