### PR TITLE
feat(ldmodel): add override marker to FeatureFlag and Segment

### DIFF
--- a/ldmodel/model_flag.go
+++ b/ldmodel/model_flag.go
@@ -109,6 +109,14 @@ type FeatureFlag struct {
 	// LaunchDarkly may affect this flag to prevent poorly performing applications from adversely
 	// affecting upstream service health.
 	ExcludeFromSummaries bool
+	// IsOverride is true if this flag definition was supplied by an SDK override source rather than
+	// by LaunchDarkly.
+	//
+	// This marker is not part of the flag data model: it is never serialized to or deserialized from
+	// JSON, and it is set only by SDK components that manage override entries. Components that read
+	// flag data can treat a flag carrying this marker the same as any other flag; the evaluator reads
+	// it to mark the evaluation reason.
+	IsOverride bool
 }
 
 // MigrationFlagParameters are used to control flag-specific migration

--- a/ldmodel/model_override_marker_easyjson_test.go
+++ b/ldmodel/model_override_marker_easyjson_test.go
@@ -1,0 +1,48 @@
+//go:build launchdarkly_easyjson
+
+package ldmodel
+
+import (
+	"testing"
+
+	"github.com/mailru/easyjson/jlexer"
+	ej_jwriter "github.com/mailru/easyjson/jwriter"
+)
+
+func TestFlagOverrideMarkerIsExcludedFromJSONEasyJSON(t *testing.T) {
+	doFlagOverrideMarkerExclusionTest(t,
+		func(flag FeatureFlag) ([]byte, error) {
+			var writer ej_jwriter.Writer
+			flag.MarshalEasyJSON(&writer)
+			if writer.Error != nil {
+				return nil, writer.Error
+			}
+			return writer.BuildBytes(nil)
+		},
+		func(data []byte) (FeatureFlag, error) {
+			lexer := jlexer.Lexer{Data: data}
+			var flag FeatureFlag
+			flag.UnmarshalEasyJSON(&lexer)
+			return flag, lexer.Error()
+		},
+	)
+}
+
+func TestSegmentOverrideMarkerIsExcludedFromJSONEasyJSON(t *testing.T) {
+	doSegmentOverrideMarkerExclusionTest(t,
+		func(segment Segment) ([]byte, error) {
+			var writer ej_jwriter.Writer
+			segment.MarshalEasyJSON(&writer)
+			if writer.Error != nil {
+				return nil, writer.Error
+			}
+			return writer.BuildBytes(nil)
+		},
+		func(data []byte) (Segment, error) {
+			lexer := jlexer.Lexer{Data: data}
+			var segment Segment
+			segment.UnmarshalEasyJSON(&lexer)
+			return segment, lexer.Error()
+		},
+	)
+}

--- a/ldmodel/model_override_marker_test.go
+++ b/ldmodel/model_override_marker_test.go
@@ -1,0 +1,109 @@
+package ldmodel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The IsOverride marker is not part of the flag/segment data model, so it must have no
+// effect on serialization, and a JSON property with the same name must not populate it.
+
+func doFlagOverrideMarkerExclusionTest(
+	t *testing.T,
+	marshalFn testMarshalFlagFn,
+	unmarshalFn testUnmarshalFlagFn,
+) {
+	for _, p := range makeFlagSerializationTestParams() {
+		t.Run(p.name, func(t *testing.T) {
+			unmarked := p.flag
+			marked := p.flag
+			marked.IsOverride = true
+
+			unmarkedJSON, err := marshalFn(unmarked)
+			require.NoError(t, err)
+			markedJSON, err := marshalFn(marked)
+			require.NoError(t, err)
+			assert.Equal(t, string(unmarkedJSON), string(markedJSON))
+			assert.NotContains(t, string(markedJSON), "sOverride")
+
+			withProperty := addPropertyToJSONObject(t, unmarkedJSON, "isOverride", true)
+			flag, err := unmarshalFn(withProperty)
+			require.NoError(t, err)
+			assert.False(t, flag.IsOverride)
+		})
+	}
+}
+
+func doSegmentOverrideMarkerExclusionTest(
+	t *testing.T,
+	marshalFn testMarshalSegmentFn,
+	unmarshalFn testUnmarshalSegmentFn,
+) {
+	for _, p := range makeSegmentSerializationTestParams() {
+		t.Run(p.name, func(t *testing.T) {
+			unmarked := p.segment
+			marked := p.segment
+			marked.IsOverride = true
+
+			unmarkedJSON, err := marshalFn(unmarked)
+			require.NoError(t, err)
+			markedJSON, err := marshalFn(marked)
+			require.NoError(t, err)
+			assert.Equal(t, string(unmarkedJSON), string(markedJSON))
+			assert.NotContains(t, string(markedJSON), "sOverride")
+
+			withProperty := addPropertyToJSONObject(t, unmarkedJSON, "isOverride", true)
+			segment, err := unmarshalFn(withProperty)
+			require.NoError(t, err)
+			assert.False(t, segment.IsOverride)
+		})
+	}
+}
+
+func addPropertyToJSONObject(t *testing.T, objectJSON []byte, name string, value interface{}) []byte {
+	var props map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(objectJSON, &props))
+	valueJSON, err := json.Marshal(value)
+	require.NoError(t, err)
+	props[name] = valueJSON
+	result, err := json.Marshal(props)
+	require.NoError(t, err)
+	return result
+}
+
+func TestFlagOverrideMarkerIsExcludedFromJSON(t *testing.T) {
+	doFlagOverrideMarkerExclusionTest(t,
+		func(flag FeatureFlag) ([]byte, error) { return json.Marshal(flag) },
+		func(data []byte) (FeatureFlag, error) {
+			var flag FeatureFlag
+			err := json.Unmarshal(data, &flag)
+			return flag, err
+		},
+	)
+	t.Run("default serialization", func(t *testing.T) {
+		doFlagOverrideMarkerExclusionTest(t,
+			NewJSONDataModelSerialization().MarshalFeatureFlag,
+			NewJSONDataModelSerialization().UnmarshalFeatureFlag,
+		)
+	})
+}
+
+func TestSegmentOverrideMarkerIsExcludedFromJSON(t *testing.T) {
+	doSegmentOverrideMarkerExclusionTest(t,
+		func(segment Segment) ([]byte, error) { return json.Marshal(segment) },
+		func(data []byte) (Segment, error) {
+			var segment Segment
+			err := json.Unmarshal(data, &segment)
+			return segment, err
+		},
+	)
+	t.Run("default serialization", func(t *testing.T) {
+		doSegmentOverrideMarkerExclusionTest(t,
+			NewJSONDataModelSerialization().MarshalSegment,
+			NewJSONDataModelSerialization().UnmarshalSegment,
+		)
+	})
+}

--- a/ldmodel/model_segment.go
+++ b/ldmodel/model_segment.go
@@ -59,6 +59,13 @@ type Segment struct {
 	// Deleted is true if this is not actually a user segment but rather a placeholder (tombstone) for a
 	// deleted segment. This is only relevant in data store implementations.
 	Deleted bool
+	// IsOverride is true if this segment definition was supplied by an SDK override source rather
+	// than by LaunchDarkly.
+	//
+	// This marker is not part of the segment data model: it is never serialized to or deserialized
+	// from JSON, and it is set only by SDK components that manage override entries. Components that
+	// read segment data can treat a segment carrying this marker the same as any other segment.
+	IsOverride bool
 	// preprocessedData is created by Segment.Preprocess() to speed up target matching.
 	preprocessed segmentPreprocessedData
 }


### PR DESCRIPTION
Adds an `IsOverride` marker field to `ldmodel.FeatureFlag` and `ldmodel.Segment`, identifying entities supplied by an SDK override source rather than by LaunchDarkly. This is the data-model piece of the SDK flag-overrides feature (OVERRIDE spec); a follow-up PR makes the evaluator reflect the marker in the evaluation reason.

The marker is carried on the typed model only and is not part of the JSON data model: both serialization paths are hand-written field lists, so the field is never written, and an `isOverride` property in input JSON is ignored like any other unknown key. New tests assert exactly that — marked and unmarked entities marshal byte-identically, and the property does not populate the field on unmarshal — across encoding/json, the DataModelSerialization interface, and the easyjson build.

No behavior change; nothing reads the field yet.

SDK-2652

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-model-only addition with no runtime readers yet; tests confirm wire format and JSON behavior stay unchanged.
> 
> **Overview**
> Adds an in-memory-only **`IsOverride`** marker on **`FeatureFlag`** and **`Segment`** so SDK override sources can tag definitions that did not come from LaunchDarkly, ahead of evaluator/reason work (OVERRIDE spec).
> 
> The field is **not** part of the JSON data model: existing hand-written serialization is unchanged, so marked vs unmarked entities marshal identically and an **`isOverride`** key in JSON does not populate the field. New tests lock that in for **`encoding/json`**, **`DataModelSerialization`**, and easyjson.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3652610871d2b3695dc8552f5b9610638d9abf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->