### PR TITLE
feat: mark evaluation reason for override-supplied flag definitions

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -16,10 +16,9 @@ import (
 // nested function/method calls; passing a pointer instead is faster. It is safe for us to do this
 // as long as the pointer value is not being retained outside the scope of this call.
 //
-// - In some for loops, we are deliberately taking the address of the range variable and using a
-// "//nolint:gosec" directive to turn off the usual linter warning about this:
+// - In some for loops, we are deliberately taking the address of the range variable:
 //       for _, x := range someThings {
-//           doSomething(&x) //nolint:gosec
+//           doSomething(&x)
 //       }
 // The rationale is the same as above, and is safe as long as the same conditions apply.
 
@@ -120,7 +119,24 @@ func (e *evaluator) Evaluate(
 		detail.Reason = ldreason.NewEvalReasonFromReasonWithBigSegmentsStatus(detail.Reason,
 			es.bigSegmentsStatus)
 	}
+	detail.Reason = reasonWithOverrideMarker(flag, detail.Reason)
 	return Result{Detail: detail, IsExperiment: isExperiment(flag, detail.Reason)}
+}
+
+// reasonWithOverrideMarker sets the reason's override indicator when the evaluated flag's
+// definition carries the override marker. The indicator reflects the source of the evaluated
+// flag itself, so it is applied only here and at the point where a prerequisite's own result
+// is reported; it is never propagated from a prerequisite or segment to the flag that
+// references it. A reason whose kind is an error is left unmarked: the result in that case
+// is the caller's default value, which did not come from the override.
+func reasonWithOverrideMarker(
+	flag *ldmodel.FeatureFlag,
+	reason ldreason.EvaluationReason,
+) ldreason.EvaluationReason {
+	if !flag.IsOverride || reason.GetKind() == ldreason.EvalReasonError {
+		return reason
+	}
+	return ldreason.NewEvalReasonFromReasonWithIsOverride(reason, true)
 }
 
 // Entry point for evaluating a flag which could be either the original flag or a prerequisite.
@@ -154,7 +170,7 @@ func (es *evaluationScope) evaluate(stack evaluationStack) (ldreason.EvaluationD
 
 	// Now walk through the rules and see if any match
 	for ruleIndex, rule := range es.flag.Rules {
-		match, err := es.ruleMatchesContext(&rule, stack) //nolint:gosec // see comments at top of file
+		match, err := es.ruleMatchesContext(&rule, stack)
 		if err != nil {
 			es.logEvaluationError(err)
 			return ldreason.NewEvaluationDetailForError(errorKindForError(err), ldvalue.Null()), false
@@ -227,9 +243,11 @@ func (es *evaluationScope) checkPrerequisites(stack evaluationStack) (ldreason.E
 		}
 
 		if es.prerequisiteFlagEventRecorder != nil {
+			prereqEventDetail := prereqResultDetail
+			prereqEventDetail.Reason = reasonWithOverrideMarker(prereqFeatureFlag, prereqEventDetail.Reason)
 			event := PrerequisiteFlagEvent{es.flag.Key, es.context, prereqFeatureFlag, Result{
-				Detail:       prereqResultDetail,
-				IsExperiment: isExperiment(prereqFeatureFlag, prereqResultDetail.Reason),
+				Detail:       prereqEventDetail,
+				IsExperiment: isExperiment(prereqFeatureFlag, prereqEventDetail.Reason),
 			}, prereqFeatureFlag.ExcludeFromSummaries}
 			es.prerequisiteFlagEventRecorder(event)
 		}
@@ -277,7 +295,7 @@ func (es *evaluationScope) anyTargetMatchVariation() ldvalue.OptionalInt {
 		// If ContextTargets is empty but Targets is not empty, then this is flag data that originally
 		// came from a non-context-aware LD endpoint or SDK. In that case, just look at Targets.
 		for _, t := range es.flag.Targets {
-			if variation := es.targetMatchVariation(&t); variation.IsDefined() { //nolint:gosec // see comments at top of file
+			if variation := es.targetMatchVariation(&t); variation.IsDefined() {
 				return variation
 			}
 		}
@@ -289,12 +307,12 @@ func (es *evaluationScope) anyTargetMatchVariation() ldvalue.OptionalInt {
 			if (t.ContextKind == "" || t.ContextKind == ldcontext.DefaultKind) && len(t.Values) == 0 {
 				for _, t1 := range es.flag.Targets {
 					if t1.Variation == t.Variation {
-						variation = es.targetMatchVariation(&t1) //nolint:gosec // see comments at top of file
+						variation = es.targetMatchVariation(&t1)
 						break
 					}
 				}
 			} else {
-				variation = es.targetMatchVariation(&t) //nolint:gosec // see comments at top of file
+				variation = es.targetMatchVariation(&t)
 			}
 			if variation.IsDefined() {
 				return variation
@@ -316,7 +334,7 @@ func (es *evaluationScope) targetMatchVariation(t *ldmodel.Target) ldvalue.Optio
 func (es *evaluationScope) ruleMatchesContext(rule *ldmodel.FlagRule, stack evaluationStack) (bool, error) {
 	// Note that rule is passed by reference only for efficiency; we do not modify it
 	for _, clause := range rule.Clauses {
-		match, err := es.clauseMatchesContext(&clause, stack) //nolint:gosec // see comments at top of file
+		match, err := es.clauseMatchesContext(&clause, stack)
 		if !match || err != nil {
 			return match, err
 		}

--- a/evaluator_override_test.go
+++ b/evaluator_override_test.go
@@ -1,0 +1,113 @@
+package evaluation
+
+import (
+	"testing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldreason"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk-evaluation/v3/ldbuilders"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var overrideTestContext = ldcontext.New("userkey")
+
+func TestOverrideFlagMarksReason(t *testing.T) {
+	t.Run("off", func(t *testing.T) {
+		flag := ldbuilders.NewFlagBuilder("feature").On(false).OffVariation(0).
+			Variations(ldvalue.String("off"), ldvalue.String("on")).Build()
+		flag.IsOverride = true
+
+		result := basicEvaluator().Evaluate(&flag, overrideTestContext, nil)
+
+		assert.Equal(t, ldreason.EvalReasonOff, result.Detail.Reason.GetKind())
+		assert.True(t, result.Detail.Reason.IsOverride())
+		assert.Equal(t, ldvalue.String("off"), result.Detail.Value)
+	})
+
+	t.Run("fallthrough", func(t *testing.T) {
+		flag := ldbuilders.NewFlagBuilder("feature").On(true).FallthroughVariation(1).
+			Variations(ldvalue.String("off"), ldvalue.String("on")).Build()
+		flag.IsOverride = true
+
+		result := basicEvaluator().Evaluate(&flag, overrideTestContext, nil)
+
+		assert.Equal(t, ldreason.EvalReasonFallthrough, result.Detail.Reason.GetKind())
+		assert.True(t, result.Detail.Reason.IsOverride())
+	})
+
+	t.Run("rule match", func(t *testing.T) {
+		flag := ldbuilders.NewFlagBuilder("feature").On(true).FallthroughVariation(0).
+			AddRule(ldbuilders.NewRuleBuilder().ID("rule-id").Variation(1).
+				Clauses(makeClauseToMatchContext(overrideTestContext))).
+			Variations(ldvalue.String("off"), ldvalue.String("on")).Build()
+		flag.IsOverride = true
+
+		result := basicEvaluator().Evaluate(&flag, overrideTestContext, nil)
+
+		assert.Equal(t, ldreason.EvalReasonRuleMatch, result.Detail.Reason.GetKind())
+		assert.True(t, result.Detail.Reason.IsOverride())
+	})
+}
+
+func TestNonOverrideFlagReasonIsNotMarked(t *testing.T) {
+	flag := ldbuilders.NewFlagBuilder("feature").On(false).OffVariation(0).
+		Variations(ldvalue.String("off"), ldvalue.String("on")).Build()
+
+	result := basicEvaluator().Evaluate(&flag, overrideTestContext, nil)
+
+	assert.Equal(t, ldreason.EvalReasonOff, result.Detail.Reason.GetKind())
+	assert.False(t, result.Detail.Reason.IsOverride())
+}
+
+func TestOverrideFlagErrorReasonIsNotMarked(t *testing.T) {
+	flag := ldbuilders.NewFlagBuilder("feature").On(true).FallthroughVariation(99).
+		Variations(ldvalue.String("off"), ldvalue.String("on")).Build()
+	flag.IsOverride = true
+
+	result := basicEvaluator().Evaluate(&flag, overrideTestContext, nil)
+
+	assert.Equal(t, ldreason.NewEvalReasonError(ldreason.EvalErrorMalformedFlag), result.Detail.Reason)
+	assert.False(t, result.Detail.Reason.IsOverride())
+}
+
+func TestOverridePrerequisiteMarksOnlyThePrerequisiteEventReason(t *testing.T) {
+	prereq := ldbuilders.NewFlagBuilder("prereq").On(true).FallthroughVariation(1).
+		Variations(ldvalue.String("nogo"), ldvalue.String("go")).Build()
+	prereq.IsOverride = true
+	flag := ldbuilders.NewFlagBuilder("feature").On(true).FallthroughVariation(1).
+		AddPrerequisite("prereq", 1).OffVariation(0).
+		Variations(ldvalue.String("off"), ldvalue.String("on")).Build()
+
+	evaluator := NewEvaluator(basicDataProvider().withStoredFlags(prereq))
+	eventSink := prereqEventSink{}
+	result := evaluator.Evaluate(&flag, overrideTestContext, eventSink.record)
+
+	assert.Equal(t, ldreason.EvalReasonFallthrough, result.Detail.Reason.GetKind())
+	assert.False(t, result.Detail.Reason.IsOverride())
+
+	require.Len(t, eventSink.events, 1)
+	prereqReason := eventSink.events[0].PrerequisiteResult.Detail.Reason
+	assert.Equal(t, ldreason.EvalReasonFallthrough, prereqReason.GetKind())
+	assert.True(t, prereqReason.IsOverride())
+}
+
+func TestNonOverridePrerequisiteEventReasonIsNotMarked(t *testing.T) {
+	prereq := ldbuilders.NewFlagBuilder("prereq").On(true).FallthroughVariation(1).
+		Variations(ldvalue.String("nogo"), ldvalue.String("go")).Build()
+	flag := ldbuilders.NewFlagBuilder("feature").On(true).FallthroughVariation(1).
+		AddPrerequisite("prereq", 1).OffVariation(0).
+		Variations(ldvalue.String("off"), ldvalue.String("on")).Build()
+	flag.IsOverride = true
+
+	evaluator := NewEvaluator(basicDataProvider().withStoredFlags(prereq))
+	eventSink := prereqEventSink{}
+	result := evaluator.Evaluate(&flag, overrideTestContext, eventSink.record)
+
+	assert.True(t, result.Detail.Reason.IsOverride())
+
+	require.Len(t, eventSink.events, 1)
+	assert.False(t, eventSink.events[0].PrerequisiteResult.Detail.Reason.IsOverride())
+}

--- a/evaluator_segment.go
+++ b/evaluator_segment.go
@@ -103,7 +103,7 @@ func (es *evaluationScope) segmentContainsContext(s *ldmodel.Segment, stack eval
 	// Check if any of the segment rules match
 	for _, rule := range s.Rules {
 		// Note, taking address of range variable here is OK because it's not used outside the loop
-		match, err := es.segmentRuleMatchesContext(&rule, stack, s.Key, s.Salt) //nolint:gosec // see comment above
+		match, err := es.segmentRuleMatchesContext(&rule, stack, s.Key, s.Salt)
 		if err != nil {
 			return false, malformedSegmentError{SegmentKey: s.Key, Err: err}
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/launchdarkly/go-server-sdk-evaluation/v3
 
-go 1.18
+go 1.23
+
+toolchain go1.24.3
 
 require (
 	github.com/launchdarkly/go-jsonstream/v3 v3.1.0
-	github.com/launchdarkly/go-sdk-common/v3 v3.1.0
+	github.com/launchdarkly/go-sdk-common/v3 v3.5.1-0.20260707203913-381c033e045f
 	github.com/launchdarkly/go-semver v1.0.3
 	github.com/launchdarkly/go-test-helpers/v3 v3.0.2
 	github.com/mailru/easyjson v0.7.7

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/launchdarkly/go-jsonstream/v3 v3.1.0 h1:U/7/LplZO72XefBQ+FzHf6o4FwLHV
 github.com/launchdarkly/go-jsonstream/v3 v3.1.0/go.mod h1:2Pt4BR5AwWgsuVTCcIpB6Os04JFIKWfoA+7faKkZB5E=
 github.com/launchdarkly/go-sdk-common/v3 v3.1.0 h1:KNCP5rfkOt/25oxGLAVgaU1BgrZnzH9Y/3Z6I8bMwDg=
 github.com/launchdarkly/go-sdk-common/v3 v3.1.0/go.mod h1:mXFmDGEh4ydK3QilRhrAyKuf9v44VZQWnINyhqbbOd0=
+github.com/launchdarkly/go-sdk-common/v3 v3.5.1-0.20260707203913-381c033e045f h1:wsrL79voFEPH70Dc6E6B9dnqWlS9nnwiKwHHw3SX7Fw=
+github.com/launchdarkly/go-sdk-common/v3 v3.5.1-0.20260707203913-381c033e045f/go.mod h1:6MNeeP8b2VtsM6I3TbShCHW/+tYh2c+p5dB+ilS69sg=
 github.com/launchdarkly/go-semver v1.0.3 h1:agIy/RN3SqeQDIfKkl+oFslEdeIs7pgsJBs3CdCcGQM=
 github.com/launchdarkly/go-semver v1.0.3/go.mod h1:xFmMwXba5Mb+3h72Z+VeSs9ahCvKo2QFUTHRNHVqR28=
 github.com/launchdarkly/go-test-helpers/v3 v3.0.2 h1:rh0085g1rVJM5qIukdaQ8z1XTWZztbJ49vRZuveqiuU=

--- a/ldmodel/parse_time.go
+++ b/ldmodel/parse_time.go
@@ -126,12 +126,12 @@ func parseDateTimeNumericField(
 
 // Attempts to parse a string as an integer greater than or equal to zero. Non-ASCII strings are not supported.
 func parsePositiveNumericString(s string) (int, bool) {
-	max := len(s)
-	if max == 0 {
+	length := len(s)
+	if length == 0 {
 		return 0, false
 	}
 	n := 0
-	for i := 0; i < max; i++ {
+	for i := 0; i < length; i++ {
 		ch := rune(s[i])
 		if ch < '0' || ch > '9' {
 			return 0, false


### PR DESCRIPTION
When the evaluated flag's definition carries the override marker, the evaluator now sets the `isOverride` indicator on the evaluation reason, using the same post-processing pattern as the big-segments status. The result value and reason kind are unchanged; a reason whose kind is an error is left unmarked, since the result in that case is the caller's default value rather than the override's.

Prerequisite evaluations are marked on the same basis: the reason reported in a `PrerequisiteFlagEvent` reflects whether the prerequisite's own definition was an override. The parent flag's reason is never marked transitively by an overridden prerequisite or segment.

Also in this change, forced by bumping go-sdk-common (for the new reason indicator): the module's minimum Go version moves from 1.18 to 1.23. That made several `//nolint:gosec` directives unused (range variables are per-iteration now, so the aliasing warning they suppressed no longer fires) and exposed a local variable shadowing the `max` builtin; both cleaned up here.

go.mod currently points at a pseudo-version of the go-sdk-common change (launchdarkly/go-sdk-common#56); it will be pinned to the released v3.6.0 before merge.

Based on #57 (the ldmodel marker fields).

SDK-2652

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core evaluation reason/event metadata and bumps Go and go-sdk-common; behavior is additive and well-tested but affects how downstream SDKs interpret evaluation results.
> 
> **Overview**
> When a flag definition has **`IsOverride`**, evaluation now sets **`isOverride`** on the evaluation reason (same post-processing style as big-segments status). Reason **kind** and returned **value** are unchanged; **error** reasons stay unmarked because the value is the caller’s default, not the override.
> 
> **Prerequisite** events get the marker only for the **prerequisite flag’s own** definition—the parent flag’s reason is **not** inherited from overridden prerequisites or segments.
> 
> The change bumps **`go-sdk-common`** (for `NewEvalReasonFromReasonWithIsOverride` / `IsOverride()`), raises the module to **Go 1.23**, drops obsolete **`//nolint:gosec`** on range-variable addresses, and renames a **`max`** local in `parse_time.go` to avoid shadowing the builtin. New tests cover override marking for off/fallthrough/rule match, errors, and prerequisite event isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8cc072613292cdf8dd91eda3054e00d9c63d3d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->